### PR TITLE
clash-verge: fix 1.6.5 build issue

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -21,8 +21,7 @@ depends=('cairo'
          'libsoup'
          'openssl'
          'webkit2gtk')
-makedepends=('cargo-tauri'
-             'jq'
+makedepends=('jq'
              'moreutils'
              'pnpm'
              'rust')
@@ -55,7 +54,9 @@ build() {
 	# export HOME=$srcdir
 	pnpm install
 	pnpm run check
-	cargo-tauri build
+	cd src-tauri
+	mkdir ../dist # placeholder to avoid compile error
+	cargo build --release
 }
 
 package() {


### PR DESCRIPTION
Removed makedepends `cargo-tauri`. Build the app with `cargo` now, with `tauri-app` at branch `1.x`.